### PR TITLE
active should be boolean

### DIFF
--- a/Doggy-Daycare-master/doggyDaycare/src/main/java/doggyDaycare/doggyDaycare/markDogInactiveServlet.java
+++ b/Doggy-Daycare-master/doggyDaycare/src/main/java/doggyDaycare/doggyDaycare/markDogInactiveServlet.java
@@ -37,7 +37,7 @@ public class markDogInactiveServlet extends HttpServlet {
 		// TODO Auto-generated method stub
 //		doGet(request, response);
 		DogDao dao = new DogDao();
-        Integer active = Integer.parseInt(request.getParameter("activeFlag"));
+        	Boolean active = Boolean.parseBoolean(request.getParameter("activeFlag"));
 
 		Integer tempId = Integer.parseInt(request.getParameter("dogId"));
 		Dog doge = dao.searchForDogById(tempId);


### PR DESCRIPTION
Keeping ORM consistent; forgot activeFlag is mapped to Boolean. TypedQuery<Dog> typedQuery = em.createQuery("select doge from Dog doge where doge.type = :selectectedActive", Dog.class); typedQuery.setParameter("selectedActive", activeDoge.getActiveFlag()); When activeDoge.ActiveFlag() = "true". We could change the the booleans to 1 or 0, but they would have to be "TINYINT(1)"